### PR TITLE
fix: change SPA fallback status code from 404 to 200

### DIFF
--- a/routes/app.go
+++ b/routes/app.go
@@ -104,7 +104,7 @@ func SetupGinRoutes(
 		c.HTML(http.StatusOK, "index.html", nil)
 	})
 	h.NoRoute(brHandler, func(c *gin.Context) {
-		c.HTML(http.StatusNotFound, "index.html", nil)
+		c.HTML(http.StatusOK, "index.html", nil)
 	})
 
 	h.POST("/api/v1/admin/prompts/test", authMiddleware, testPrompt)


### PR DESCRIPTION
This PR fixes issue #92 by changing the SPA fallback status code from 404 to 200.

When serving index.html for unmatched routes in SPA mode, we now return 200 status instead of 404 since we're successfully serving the index.html file.

Changes:
- Modified `routes/app.go` line 107 to use `http.StatusOK` instead of `http.StatusNotFound`

Fixes #92

Generated with [Claude Code](https://claude.ai/code)