### PR TITLE
feat: change authentication from username+password to email+password

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,10 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/speps/go-hashids/v2 v2.0.1 h1:ViWOEqWES/pdOSq+C1SLVa8/Tnsd52XC34RY7lt7m4g=
 github.com/speps/go-hashids/v2 v2.0.1/go.mod h1:47LKunwvDZki/uRVD6NImtyk712yFzIs3UF3KlHohGw=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/routes/user.go
+++ b/routes/user.go
@@ -80,7 +80,7 @@ func authHandler(c *gin.Context) {
 }
 
 type passwordAuthPayload struct {
-	Username string `json:"username" binding:"required"`
+	Email string `json:"email" binding:"required"`
 	Password string `json:"password" binding:"required"`
 }
 
@@ -96,21 +96,10 @@ func passwordAuthHandler(c *gin.Context) {
 
 	passwordService := service.NewPasswordService()
 
-	// Try to find user by username or email
-	var u *ent.User
-	var err error
-
-	// First try to find by username
-	u, err = service.EntClient.User.Query().
-		Where(user.Username(payload.Username)).
+	// Find user by email
+	u, err := service.EntClient.User.Query().
+		Where(user.Email(payload.Email)).
 		Only(c)
-
-	// If not found by username, try by email
-	if ent.IsNotFound(err) {
-		u, err = service.EntClient.User.Query().
-			Where(user.Email(payload.Username)).
-			Only(c)
-	}
 
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, errorResponse{

--- a/schema/auth.go
+++ b/schema/auth.go
@@ -74,7 +74,7 @@ type passwordAuthInput struct {
 }
 
 type passwordAuthData struct {
-	Username string
+	Email string
 	Password string
 }
 
@@ -82,20 +82,10 @@ func (q QueryResolver) PasswordAuth(ctx context.Context, args passwordAuthInput)
 	payload := args.Auth
 	passwordService := service.NewPasswordService()
 
-	// Try to find user by username or email
-	var u *ent.User
-
-	// First try to find by username
-	u, err = service.EntClient.User.Query().
-		Where(user.Username(payload.Username)).
+	// Find user by email
+	u, err := service.EntClient.User.Query().
+		Where(user.Email(payload.Email)).
 		Only(ctx)
-
-	// If not found by username, try by email
-	if ent.IsNotFound(err) {
-		u, err = service.EntClient.User.Query().
-			Where(user.Email(payload.Username)).
-			Only(ctx)
-	}
 
 	if err != nil {
 		err = NewGraphQLHttpError(http.StatusUnauthorized, errors.New("invalid credentials"))

--- a/schema/types/user.gql
+++ b/schema/types/user.gql
@@ -5,7 +5,7 @@ input AuthInput {
 }
 
 input PasswordAuthInput {
-  username: String!
+  email: String!
   password: String!
 }
 


### PR DESCRIPTION
This PR changes the authentication system from username+password to email+password as requested in issue #104.

## Changes
- Update GraphQL PasswordAuthInput to use email field instead of username
- Remove username-based authentication fallback in both GraphQL and HTTP routes
- Update authentication logic to only lookup users by email
- Update all test cases to use email-based authentication

Closes #104

Generated with [Claude Code](https://claude.ai/code)