### PR TITLE
Add provider information support to promptcall and webhook functionality

### DIFF
--- a/ent/schema/project.go
+++ b/ent/schema/project.go
@@ -33,7 +33,7 @@ func (Project) Fields() []ent.Field {
 		field.Float("openAITemperature").Default(1),
 		field.Float("openAITopP").Default(0.9),
 		field.Int("openAIMaxTokens").Default(0),
-		field.Int("providerId").Optional().StorageKey("project_provider"),
+		field.Int("providerId").Optional().Nillable().StorageKey("project_provider"),
 	}
 }
 

--- a/ent/schema/promptcall.go
+++ b/ent/schema/promptcall.go
@@ -30,6 +30,8 @@ func (PromptCall) Fields() []ent.Field {
 		field.String("ip").Default(""),
 		// only available when prompt.debug is true
 		field.String("message").Optional().Nillable(),
+		// provider information
+		field.Int("providerId").Optional().Nillable().StorageKey("prompt_call_provider"),
 	}
 }
 
@@ -42,6 +44,10 @@ func (PromptCall) Edges() []ent.Edge {
 			Field("promptId").
 			Required(),
 		edge.From("project", Project.Type).Ref("calls").Unique(),
+		edge.From("provider", Provider.Type).
+			Ref("promptCalls").
+			Unique().
+			Field("providerId"),
 	}
 }
 

--- a/ent/schema/provider.go
+++ b/ent/schema/provider.go
@@ -62,6 +62,12 @@ func (Provider) Edges() []ent.Edge {
 			From("creator", User.Type).
 			Ref("providers").
 			Unique(),
+
+		// A provider can have many prompt calls
+		edge.To("promptCalls", PromptCall.Type),
+
+		// A provider can have many webhook calls
+		edge.To("webhookCalls", WebhookCall.Type),
 	}
 }
 

--- a/ent/schema/webhook_call.go
+++ b/ent/schema/webhook_call.go
@@ -30,6 +30,8 @@ func (WebhookCall) Fields() []ent.Field {
 		field.String("error_message").Optional().Comment("Error message if call failed"),
 		field.String("user_agent").Optional().Comment("User-Agent header sent with request"),
 		field.String("ip").Optional().Comment("IP address of the client that triggered the webhook"),
+		// provider information
+		field.Int("providerId").Optional().StorageKey("webhook_call_provider").Comment("ID of the AI provider used"),
 	}
 }
 
@@ -42,6 +44,10 @@ func (WebhookCall) Edges() []ent.Edge {
 			Unique().
 			Field("webhook_id").
 			Required(),
+		edge.From("provider", Provider.Type).
+			Ref("webhookCalls").
+			Unique().
+			Field("providerId"),
 	}
 }
 

--- a/routes/prompt.api.go
+++ b/routes/prompt.api.go
@@ -409,6 +409,11 @@ func savePromptCall(
 		SetUa(ua)
 		// SetUa(c.Request.UserAgent())
 
+	// Set provider information if available
+	if pj.ProviderId != nil {
+		stat.SetProviderID(*pj.ProviderId)
+	}
+
 	if prompt.Debug {
 		stat.SetPayload(payload.Variables)
 	}
@@ -432,5 +437,5 @@ func savePromptCall(
 	}
 
 	// Trigger webhooks in background
-go triggerWebhooks(context.Background(), pj, prompt, responseResult, res, payload, endTime, startTime, ua, clientIP, isCachedResponse)
+go triggerWebhooks(context.Background(), pj, prompt, responseResult, res, payload, endTime, startTime, ua, clientIP, isCachedResponse, pj.ProviderId)
 }

--- a/routes/webhook.service.go
+++ b/routes/webhook.service.go
@@ -36,9 +36,10 @@ type WebhookPayload struct {
 		Completion int `json:"completion"`
 		Total      int `json:"total"`
 	} `json:"tokens"`
-	Cached    bool   `json:"cached"`
-	IP        string `json:"ip"`
-	UserAgent string `json:"userAgent"`
+	Cached     bool   `json:"cached"`
+	IP         string `json:"ip"`
+	UserAgent  string `json:"userAgent"`
+	ProviderID *int   `json:"providerId,omitempty"`
 }
 
 // WebhookCallData holds all the information needed to record a webhook call
@@ -57,6 +58,7 @@ type WebhookCallData struct {
 	ErrorMessage    string
 	UserAgent       string
 	IP              string
+	ProviderID      *int
 }
 
 // triggerWebhooks sends webhook notifications for onPromptFinished events
@@ -71,6 +73,7 @@ func triggerWebhooks(
 	ua string,
 	clientIP string,
 	isCachedResponse bool,
+	providerID *int,
 ) {
 	// Use background context to avoid cancellation when request completes
 	backgroundCtx := context.Background()
@@ -94,16 +97,17 @@ func triggerWebhooks(
 
 	// Prepare webhook payload
 	webhookPayload := WebhookPayload{
-		Event:     "onPromptFinished",
-		ProjectID: pj.ID,
-		PromptID:  prompt.ID,
-		UserID:    payload.UserId,
-		Result:    responseResult,
-		Timestamp: endTime.Format(time.RFC3339),
-		Duration:  endTime.Sub(startTime).Milliseconds(),
-		Cached:    isCachedResponse,
-		IP:        clientIP,
-		UserAgent: ua,
+		Event:      "onPromptFinished",
+		ProjectID:  pj.ID,
+		PromptID:   prompt.ID,
+		UserID:     payload.UserId,
+		Result:     responseResult,
+		Timestamp:  endTime.Format(time.RFC3339),
+		Duration:   endTime.Sub(startTime).Milliseconds(),
+		Cached:     isCachedResponse,
+		IP:         clientIP,
+		UserAgent:  ua,
+		ProviderID: providerID,
 	}
 
 	webhookPayload.Tokens.Prompt = res.Usage.PromptTokens
@@ -121,12 +125,12 @@ func triggerWebhooks(
 
 	// Send webhook requests
 	for _, webhook := range webhooks {
-		go sendWebhookRequest(backgroundCtx, webhook, payloadBytes, traceID, clientIP)
+		go sendWebhookRequest(backgroundCtx, webhook, payloadBytes, traceID, clientIP, providerID)
 	}
 }
 
 // sendWebhookRequest sends a single webhook request and records the call details
-func sendWebhookRequest(ctx context.Context, webhook *ent.Webhook, payloadBytes []byte, traceID string, clientIP string) {
+func sendWebhookRequest(ctx context.Context, webhook *ent.Webhook, payloadBytes []byte, traceID string, clientIP string, providerID *int) {
 	startTime := time.Now()
 
 	// Prepare request headers
@@ -154,6 +158,7 @@ func sendWebhookRequest(ctx context.Context, webhook *ent.Webhook, payloadBytes 
 			ErrorMessage:    err.Error(),
 			UserAgent:       requestHeaders["User-Agent"],
 			IP:              clientIP,
+			ProviderID:      providerID,
 		})
 		return
 	}
@@ -233,6 +238,7 @@ func sendWebhookRequest(ctx context.Context, webhook *ent.Webhook, payloadBytes 
 		ErrorMessage:    errorMessage,
 		UserAgent:       requestHeaders["User-Agent"],
 		IP:              clientIP,
+		ProviderID:      providerID,
 	})
 }
 
@@ -267,6 +273,9 @@ func recordWebhookCall(ctx context.Context, data WebhookCallData) {
 	}
 	if data.IP != "" {
 		call = call.SetIP(data.IP)
+	}
+	if data.ProviderID != nil {
+		call = call.SetProviderID(*data.ProviderID)
 	}
 
 	_, err := call.Save(ctx)

--- a/service/ai.isomorphic.go
+++ b/service/ai.isomorphic.go
@@ -70,15 +70,16 @@ func (o isomorphicAIService) getIsomorphicClient(ctx context.Context, provider *
 }
 
 func (o isomorphicAIService) GetProvider(ctx context.Context, prompt ent.Prompt) (provider *ent.Provider, err error) {
-	promptProvider, err := EntClient.Provider.Get(ctx, prompt.ProviderId)
-
-	if err != nil && !ent.IsNotFound(err) {
-		return
-	}
-
-	if err == nil && promptProvider != nil {
-		provider = promptProvider
-		return
+	var promptProvider *ent.Provider
+	if prompt.ProviderId > 0 {
+		promptProvider, err = EntClient.Provider.Get(ctx, prompt.ProviderId)
+		if err != nil && !ent.IsNotFound(err) {
+			return
+		}
+		if err == nil && promptProvider != nil {
+			provider = promptProvider
+			return
+		}
 	}
 
 	err = nil
@@ -88,9 +89,12 @@ func (o isomorphicAIService) GetProvider(ctx context.Context, prompt ent.Prompt)
 		return
 	}
 
-	projectProvider, err := EntClient.Provider.Get(ctx, pj.ProviderId)
-	if err != nil && !ent.IsNotFound(err) {
-		return
+	var projectProvider *ent.Provider
+	if pj.ProviderId != nil {
+		projectProvider, err = EntClient.Provider.Get(ctx, *pj.ProviderId)
+		if err != nil && !ent.IsNotFound(err) {
+			return
+		}
 	}
 	if err == nil && projectProvider != nil {
 		provider = projectProvider


### PR DESCRIPTION
Fixes #116

Adds provider information tracking to both prompt calls and webhook functionality as requested.

## Changes
- Added `providerId` fields to PromptCall and WebhookCall database schemas
- Updated triggerWebhooks functions to accept and record provider information
- Added provider ID to webhook payload for external notifications
- Added proper relationship edges between Provider and call entities
- Fixed nullable provider ID handling throughout the codebase

## Testing
- Code compiles successfully
- Database schema generation works correctly
- Provider information is now tracked for analytics and monitoring

Generated with [Claude Code](https://claude.ai/code)