### PR TITLE
feat(webhook): add webhook resolver for fetching single webhook

### DIFF
--- a/schema/schema.gql
+++ b/schema/schema.gql
@@ -28,6 +28,7 @@ type Query {
   providers(pagination: PaginationInput!): ProviderList!
 
   # Webhook queries
+  webhook(id: Int!): Webhook!
   webhooks(projectId: Int!, pagination: PaginationInput!): WebhookList!
 }
 

--- a/schema/webhook_test.go
+++ b/schema/webhook_test.go
@@ -367,6 +367,99 @@ func (s *webhookTestSuite) TestDeleteWebhook_NotFound() {
 	assert.Equal(s.T(), http.StatusNotFound, ge.code)
 }
 
+func (s *webhookTestSuite) TestWebhook_Success() {
+	// First create a webhook
+	webhook, err := s.q.CreateWebhook(s.ctx, createWebhookArgs{
+		Data: createWebhookData{
+			Name:      "Single Test Webhook",
+			URL:       "https://example.com/webhook",
+			Event:     EventOnPromptFinished,
+			ProjectID: int32(s.projectID),
+		},
+	})
+	assert.Nil(s.T(), err)
+
+	// Get single webhook by ID
+	result, err := s.q.Webhook(s.ctx, webhookArgs{
+		ID: webhook.ID(),
+	})
+
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), result.w)
+	assert.Equal(s.T(), webhook.ID(), result.ID())
+	assert.Equal(s.T(), "Single Test Webhook", result.Name())
+	assert.Equal(s.T(), "https://example.com/webhook", result.URL())
+	assert.Equal(s.T(), EventOnPromptFinished, result.Event())
+
+	// Clean up
+	service.EntClient.Webhook.DeleteOneID(int(webhook.ID())).ExecX(context.Background())
+}
+
+func (s *webhookTestSuite) TestWebhook_NotFound() {
+	// Try to get non-existent webhook
+	_, err := s.q.Webhook(s.ctx, webhookArgs{
+		ID: 99999,
+	})
+
+	assert.Error(s.T(), err)
+	ge, ok := err.(GraphQLHttpError)
+	assert.True(s.T(), ok)
+	assert.Equal(s.T(), http.StatusNotFound, ge.code)
+}
+
+func (s *webhookTestSuite) TestWebhook_UnauthorizedAccess() {
+	// Create a webhook
+	webhook, err := s.q.CreateWebhook(s.ctx, createWebhookArgs{
+		Data: createWebhookData{
+			Name:      "Unauthorized Test Webhook",
+			URL:       "https://example.com/webhook",
+			Event:     EventOnPromptFinished,
+			ProjectID: int32(s.projectID),
+		},
+	})
+	assert.Nil(s.T(), err)
+
+	// Create another user without permissions
+	testUserName := "unauthorized-user-webhook-single-" + utils.RandStringRunes(8)
+	testUserAddr := "unauthorized-addr-webhook-single-" + utils.RandStringRunes(8)
+	testUserEmail := testUserAddr + "@test-webhook.com"
+
+	unauthorizedUser := service.
+		EntClient.
+		User.
+		Create().
+		SetAddr(testUserAddr).
+		SetName(testUserName).
+		SetLang("en").
+		SetPhone(utils.RandStringRunes(16)).
+		SetLevel(0). // No admin level
+		SetEmail(testUserEmail).
+		SaveX(context.Background())
+
+	unauthorizedCtx := context.WithValue(context.Background(), service.GinGraphQLContextKey, service.GinGraphQLContextType{
+		UserID: unauthorizedUser.ID,
+	})
+
+	// Mock RBAC to return false for unauthorized user
+	rbac := service.NewMockRBACService(s.T())
+	rbac.On("HasPermission", mock.Anything, unauthorizedUser.ID, mock.Anything, service.PermProjectView).Return(false, nil)
+	rbacService = rbac
+
+	// Try to get webhook without permissions
+	_, err = s.q.Webhook(unauthorizedCtx, webhookArgs{
+		ID: webhook.ID(),
+	})
+
+	assert.Error(s.T(), err)
+	ge, ok := err.(GraphQLHttpError)
+	assert.True(s.T(), ok)
+	assert.Equal(s.T(), http.StatusUnauthorized, ge.code)
+
+	// Clean up
+	service.EntClient.Webhook.DeleteOneID(int(webhook.ID())).ExecX(context.Background())
+	service.EntClient.User.DeleteOneID(unauthorizedUser.ID).ExecX(context.Background())
+}
+
 func (s *webhookTestSuite) TestWebhooks_Success() {
 	// First create a webhook
 	webhook, err := s.q.CreateWebhook(s.ctx, createWebhookArgs{


### PR DESCRIPTION
Add `webhook(id: Int!): Webhook!` resolver for fetching single webhook, similar to existing `webhooks` resolver.

## Changes
- Add webhook field to GraphQL schema
- Implement resolver logic with RBAC permission checks
- Add comprehensive tests for all scenarios
- Follow established patterns from other single-entity resolvers

Resolves #120

Generated with [Claude Code](https://claude.ai/code)