### PR TITLE
feat: implement cost report feature with GraphQL API

### DIFF
--- a/ent/schema/costreport.go
+++ b/ent/schema/costreport.go
@@ -1,0 +1,78 @@
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
+	"entgo.io/ent/schema/mixin"
+)
+
+// CostReport holds aggregated cost data by month for performance optimization
+type CostReport struct {
+	ent.Schema
+}
+
+// Fields of the CostReport.
+func (CostReport) Fields() []ent.Field {
+	return []ent.Field{
+		// Month in YYYY-MM format
+		field.String("month").
+			Comment("Month in YYYY-MM format (e.g., '2024-01')"),
+		// User ID to scope the report
+		field.String("userId").
+			Comment("User ID this report belongs to"),
+		// Total costs for the month
+		field.Float("totalCostCents").
+			Default(0).
+			Comment("Total cost in cents for the month"),
+		// Aggregated costs by different dimensions as JSON
+		field.JSON("costsByProvider", map[string]float64{}).
+			Default(map[string]float64{}).
+			Comment("Costs grouped by provider ID -> cost in cents"),
+		field.JSON("costsByProject", map[string]float64{}).
+			Default(map[string]float64{}).
+			Comment("Costs grouped by project ID -> cost in cents"),
+		field.JSON("costsByPrompt", map[string]float64{}).
+			Default(map[string]float64{}).
+			Comment("Costs grouped by prompt ID -> cost in cents"),
+		field.JSON("costsByDay", map[string]float64{}).
+			Default(map[string]float64{}).
+			Comment("Costs grouped by day (YYYY-MM-DD) -> cost in cents"),
+		// Additional metrics
+		field.Int("totalCalls").
+			Default(0).
+			Comment("Total number of prompt calls in the month"),
+		field.Int("totalTokens").
+			Default(0).
+			Comment("Total tokens consumed in the month"),
+		field.Int("successfulCalls").
+			Default(0).
+			Comment("Number of successful calls (result = 0)"),
+		field.Int("cachedCalls").
+			Default(0).
+			Comment("Number of cached calls"),
+	}
+}
+
+// Edges of the CostReport.
+func (CostReport) Edges() []ent.Edge {
+	return []ent.Edge{}
+}
+
+// Indexes of the CostReport.
+func (CostReport) Indexes() []ent.Index {
+	return []ent.Index{
+		// Unique index on userId + month combination
+		index.Fields("userId", "month").Unique(),
+		// Index for efficient querying by month range
+		index.Fields("month"),
+		// Index for efficient querying by user
+		index.Fields("userId"),
+	}
+}
+
+func (CostReport) Mixin() []ent.Mixin {
+	return []ent.Mixin{
+		mixin.Time{},
+	}
+}

--- a/schema/cost_report.go
+++ b/schema/cost_report.go
@@ -1,0 +1,173 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/PromptPal/PromptPal/service"
+)
+
+// reports(filters: CostReportFilters!): CostReportList!
+type costReportFilters struct {
+	From string
+	To   string
+}
+
+type reportsArgs struct {
+	Filters costReportFilters
+}
+
+type costReportListResponse struct {
+	reports []service.MonthlyCostReport
+}
+
+// Reports resolves the main cost reports query
+func (q QueryResolver) Reports(ctx context.Context, args reportsArgs) (costReportListResponse, error) {
+	// Get user ID from context
+	ctxValue := ctx.Value(service.GinGraphQLContextKey).(service.GinGraphQLContextType)
+	userID := fmt.Sprintf("%d", ctxValue.UserID)
+
+	// Validate date format
+	if _, err := time.Parse("2006-01", args.Filters.From); err != nil {
+		return costReportListResponse{}, NewGraphQLHttpError(http.StatusBadRequest, err)
+	}
+	if _, err := time.Parse("2006-01", args.Filters.To); err != nil {
+		return costReportListResponse{}, NewGraphQLHttpError(http.StatusBadRequest, err)
+	}
+
+	// Use the cost report service to get the reports
+	costReportService := &service.CostReportService{}
+	reports, err := costReportService.GetCostReports(ctx, userID, args.Filters.From, args.Filters.To)
+	if err != nil {
+		return costReportListResponse{}, NewGraphQLHttpError(http.StatusInternalServerError, err)
+	}
+
+	return costReportListResponse{reports: reports}, nil
+}
+
+// Reports method returns the list of monthly cost reports
+func (r costReportListResponse) Reports() []monthlyCostReportResponse {
+	var result []monthlyCostReportResponse
+	for _, report := range r.reports {
+		result = append(result, monthlyCostReportResponse{report: report})
+	}
+	return result
+}
+
+// Count returns the number of reports
+func (r costReportListResponse) Count() int32 {
+	return int32(len(r.reports))
+}
+
+// monthlyCostReportResponse wraps a MonthlyCostReport for GraphQL
+type monthlyCostReportResponse struct {
+	report service.MonthlyCostReport
+}
+
+func (r monthlyCostReportResponse) Month() string {
+	return r.report.Month
+}
+
+func (r monthlyCostReportResponse) UserId() string {
+	return r.report.UserID
+}
+
+func (r monthlyCostReportResponse) TotalCostCents() float64 {
+	return r.report.TotalCostCents
+}
+
+func (r monthlyCostReportResponse) TotalCalls() int32 {
+	return int32(r.report.TotalCalls)
+}
+
+func (r monthlyCostReportResponse) TotalTokens() int32 {
+	return int32(r.report.TotalTokens)
+}
+
+func (r monthlyCostReportResponse) SuccessfulCalls() int32 {
+	return int32(r.report.SuccessfulCalls)
+}
+
+func (r monthlyCostReportResponse) CachedCalls() int32 {
+	return int32(r.report.CachedCalls)
+}
+
+func (r monthlyCostReportResponse) CostsByProvider() []costBreakdownItemResponse {
+	var result []costBreakdownItemResponse
+	for _, item := range r.report.CostsByProvider {
+		result = append(result, costBreakdownItemResponse{item: item})
+	}
+	return result
+}
+
+func (r monthlyCostReportResponse) CostsByProject() []costBreakdownItemResponse {
+	var result []costBreakdownItemResponse
+	for _, item := range r.report.CostsByProject {
+		result = append(result, costBreakdownItemResponse{item: item})
+	}
+	return result
+}
+
+func (r monthlyCostReportResponse) CostsByPrompt() []costBreakdownItemResponse {
+	var result []costBreakdownItemResponse
+	for _, item := range r.report.CostsByPrompt {
+		result = append(result, costBreakdownItemResponse{item: item})
+	}
+	return result
+}
+
+func (r monthlyCostReportResponse) CostsByDay() []dailyCostResponse {
+	var result []dailyCostResponse
+	for _, cost := range r.report.CostsByDay {
+		result = append(result, dailyCostResponse{cost: cost})
+	}
+	return result
+}
+
+func (r monthlyCostReportResponse) CreatedAt() string {
+	return r.report.CreatedAt.Format(time.RFC3339)
+}
+
+func (r monthlyCostReportResponse) UpdatedAt() string {
+	return r.report.UpdatedAt.Format(time.RFC3339)
+}
+
+// costBreakdownItemResponse wraps a CostBreakdownItem for GraphQL
+type costBreakdownItemResponse struct {
+	item service.CostBreakdownItem
+}
+
+func (r costBreakdownItemResponse) ID() string {
+	return r.item.ID
+}
+
+func (r costBreakdownItemResponse) Name() string {
+	return r.item.Name
+}
+
+func (r costBreakdownItemResponse) CostCents() float64 {
+	return r.item.CostCents
+}
+
+func (r costBreakdownItemResponse) Count() int32 {
+	return int32(r.item.Count)
+}
+
+// dailyCostResponse wraps a DailyCost for GraphQL
+type dailyCostResponse struct {
+	cost service.DailyCost
+}
+
+func (r dailyCostResponse) Date() string {
+	return r.cost.Date
+}
+
+func (r dailyCostResponse) CostCents() float64 {
+	return r.cost.CostCents
+}
+
+func (r dailyCostResponse) Count() int32 {
+	return int32(r.cost.Count)
+}

--- a/schema/cost_report_test.go
+++ b/schema/cost_report_test.go
@@ -1,0 +1,465 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/PromptPal/PromptPal/config"
+	"github.com/PromptPal/PromptPal/ent"
+	"github.com/PromptPal/PromptPal/service"
+	"github.com/PromptPal/PromptPal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type costReportTestSuite struct {
+	suite.Suite
+	uid       int
+	projectID int
+	promptID  int
+	provider  *ent.Provider
+	q         QueryResolver
+	ctx       context.Context
+}
+
+func (s *costReportTestSuite) SetupSuite() {
+	config.SetupConfig(true)
+	w3 := service.NewWeb3Service()
+	hs := service.NewHashIDService()
+
+	service.InitDB()
+	service.InitRedis(config.GetRuntimeConfig().RedisURL)
+
+	rbac := service.NewMockRBACService(s.T())
+	// Configure mock expectations for RBAC permissions
+	Setup(hs, w3, rbac)
+
+	s.q = QueryResolver{}
+
+	// Create test user
+	uniqueAddr := fmt.Sprintf("test-cost-report-%s", utils.RandStringRunes(8))
+	uniqueEmail := fmt.Sprintf("test-cost-report-%s@annatarhe.com", utils.RandStringRunes(8))
+	u := service.
+		EntClient.
+		User.
+		Create().
+		SetAddr(uniqueAddr).
+		SetName(utils.RandStringRunes(16)).
+		SetLang("en").
+		SetPhone(utils.RandStringRunes(16)).
+		SetLevel(255).
+		SetEmail(uniqueEmail).
+		SaveX(context.Background())
+	s.uid = u.ID
+
+	s.ctx = context.WithValue(context.Background(), service.GinGraphQLContextKey, service.GinGraphQLContextType{
+		UserID: s.uid,
+	})
+
+	// Create test project
+	project := service.
+		EntClient.
+		Project.
+		Create().
+		SetName(fmt.Sprintf("Test Project %s", utils.RandStringRunes(8))).
+		SetCreatorID(s.uid).
+		SaveX(context.Background())
+	s.projectID = project.ID
+
+	// Create test provider
+	provider := service.
+		EntClient.
+		Provider.
+		Create().
+		SetName(fmt.Sprintf("Test Provider %s", utils.RandStringRunes(8))).
+		SetEndpoint("https://api.openai.com/v1").
+		SetApiKey("sk-test").
+		SetSource("openai").
+		SetCreatorID(s.uid).
+		SaveX(context.Background())
+	s.provider = provider
+
+	// Create test prompt
+	prompt := service.
+		EntClient.
+		Prompt.
+		Create().
+		SetName(fmt.Sprintf("Test Prompt %s", utils.RandStringRunes(8))).
+		SetDescription("Test prompt for cost report tests").
+		SetCreatorID(s.uid).
+		SetProjectID(s.projectID).
+		SaveX(context.Background())
+	s.promptID = prompt.ID
+}
+
+func (s *costReportTestSuite) TestReports_Success() {
+	// Create test prompt calls with different costs and dates
+	now := time.Now()
+	currentMonth := now.Format("2006-01")
+	lastMonth := now.AddDate(0, -1, 0).Format("2006-01")
+
+	// Create calls for current month
+	s.createTestPromptCall(100.50, 1000, 800, now.AddDate(0, 0, -5), 0, false)
+	s.createTestPromptCall(200.75, 1500, 1200, now.AddDate(0, 0, -3), 0, false)
+	s.createTestPromptCall(50.25, 500, 400, now.AddDate(0, 0, -1), 0, true)
+
+	// Create calls for last month
+	lastMonthTime := now.AddDate(0, -1, 0)
+	s.createTestPromptCall(300.00, 2000, 1600, lastMonthTime.AddDate(0, 0, -10), 0, false)
+	s.createTestPromptCall(150.25, 1200, 1000, lastMonthTime.AddDate(0, 0, -5), 1, false)
+
+	// Query cost reports for both months
+	result, err := s.q.Reports(s.ctx, reportsArgs{
+		Filters: costReportFilters{
+			From: lastMonth,
+			To:   currentMonth,
+		},
+	})
+
+	assert.Nil(s.T(), err)
+	assert.NotNil(s.T(), result.reports)
+
+	// Check count
+	count := result.Count()
+	assert.Equal(s.T(), int32(2), count)
+
+	// Check reports
+	reports := result.Reports()
+	assert.Len(s.T(), reports, 2)
+
+	// Verify current month report
+	var currentMonthReport, lastMonthReport monthlyCostReportResponse
+	for _, report := range reports {
+		if report.Month() == currentMonth {
+			currentMonthReport = report
+		} else if report.Month() == lastMonth {
+			lastMonthReport = report
+		}
+	}
+
+	// Verify current month data
+	assert.Equal(s.T(), currentMonth, currentMonthReport.Month())
+	assert.Equal(s.T(), s.uid, currentMonthReport.UserId())
+	assert.Equal(s.T(), 351.50, currentMonthReport.TotalCostCents()) // 100.50 + 200.75 + 50.25
+	assert.Equal(s.T(), int32(3), currentMonthReport.TotalCalls())
+	assert.Equal(s.T(), int32(3000), currentMonthReport.TotalTokens()) // 1000 + 1500 + 500
+	assert.Equal(s.T(), int32(3), currentMonthReport.SuccessfulCalls()) // All have result = 0
+	assert.Equal(s.T(), int32(1), currentMonthReport.CachedCalls()) // One cached call
+
+	// Verify last month data
+	assert.Equal(s.T(), lastMonth, lastMonthReport.Month())
+	assert.Equal(s.T(), s.uid, lastMonthReport.UserId())
+	assert.Equal(s.T(), 450.25, lastMonthReport.TotalCostCents()) // 300.00 + 150.25
+	assert.Equal(s.T(), int32(2), lastMonthReport.TotalCalls())
+	assert.Equal(s.T(), int32(3200), lastMonthReport.TotalTokens()) // 2000 + 1200
+	assert.Equal(s.T(), int32(1), lastMonthReport.SuccessfulCalls()) // One success, one fail
+	assert.Equal(s.T(), int32(0), lastMonthReport.CachedCalls()) // No cached calls
+
+	// Verify breakdown data exists
+	assert.NotEmpty(s.T(), currentMonthReport.CostsByProvider())
+	assert.NotEmpty(s.T(), currentMonthReport.CostsByProject())
+	assert.NotEmpty(s.T(), currentMonthReport.CostsByPrompt())
+	assert.NotEmpty(s.T(), currentMonthReport.CostsByDay())
+}
+
+func (s *costReportTestSuite) TestReports_SingleMonth() {
+	// Create test prompt calls for current month only
+	now := time.Now()
+	currentMonth := now.Format("2006-01")
+
+	call1 := s.createTestPromptCall(125.75, 1000, 800, now.AddDate(0, 0, -5), 0, false)
+	call2 := s.createTestPromptCall(275.25, 1500, 1200, now.AddDate(0, 0, -3), 0, false)
+
+	// Query cost reports for current month only
+	result, err := s.q.Reports(s.ctx, reportsArgs{
+		Filters: costReportFilters{
+			From: currentMonth,
+			To:   currentMonth,
+		},
+	})
+
+	assert.Nil(s.T(), err)
+
+	// Check count
+	count := result.Count()
+	assert.Equal(s.T(), int32(1), count)
+
+	// Check reports
+	reports := result.Reports()
+	assert.Len(s.T(), reports, 1)
+
+	report := reports[0]
+	assert.Equal(s.T(), currentMonth, report.Month())
+	assert.Equal(s.T(), 401.00, report.TotalCostCents()) // 125.75 + 275.25
+	assert.Equal(s.T(), int32(2), report.TotalCalls())
+
+	// Clean up
+	service.EntClient.PromptCall.DeleteOneID(call1.ID).ExecX(context.Background())
+	service.EntClient.PromptCall.DeleteOneID(call2.ID).ExecX(context.Background())
+}
+
+func (s *costReportTestSuite) TestReports_NoData() {
+	// Query for a month with no data
+	futureMonth := time.Now().AddDate(0, 2, 0).Format("2006-01")
+
+	result, err := s.q.Reports(s.ctx, reportsArgs{
+		Filters: costReportFilters{
+			From: futureMonth,
+			To:   futureMonth,
+		},
+	})
+
+	assert.Nil(s.T(), err)
+
+	// Should return empty report for the month
+	count := result.Count()
+	assert.Equal(s.T(), int32(1), count)
+
+	reports := result.Reports()
+	assert.Len(s.T(), reports, 1)
+
+	report := reports[0]
+	assert.Equal(s.T(), futureMonth, report.Month())
+	assert.Equal(s.T(), 0.0, report.TotalCostCents())
+	assert.Equal(s.T(), int32(0), report.TotalCalls())
+}
+
+func (s *costReportTestSuite) TestReports_InvalidDateFormat() {
+	// Test invalid from date
+	_, err := s.q.Reports(s.ctx, reportsArgs{
+		Filters: costReportFilters{
+			From: "2024-13", // Invalid month
+			To:   "2024-01",
+		},
+	})
+
+	assert.Error(s.T(), err)
+	ge, ok := err.(GraphQLHttpError)
+	assert.True(s.T(), ok)
+	assert.Equal(s.T(), http.StatusBadRequest, ge.code)
+
+	// Test invalid to date
+	_, err = s.q.Reports(s.ctx, reportsArgs{
+		Filters: costReportFilters{
+			From: "2024-01",
+			To:   "invalid-date",
+		},
+	})
+
+	assert.Error(s.T(), err)
+	ge, ok = err.(GraphQLHttpError)
+	assert.True(s.T(), ok)
+	assert.Equal(s.T(), http.StatusBadRequest, ge.code)
+}
+
+func (s *costReportTestSuite) TestReports_CostBreakdownItems() {
+	// Create test prompt calls with different providers/projects
+	now := time.Now()
+	currentMonth := now.Format("2006-01")
+
+	// Create a second project and prompt
+	project2 := service.
+		EntClient.
+		Project.
+		Create().
+		SetName(fmt.Sprintf("Test Project 2 %s", utils.RandStringRunes(8))).
+		SetCreatorID(s.uid).
+		SaveX(context.Background())
+
+	prompt2 := service.
+		EntClient.
+		Prompt.
+		Create().
+		SetName(fmt.Sprintf("Test Prompt 2 %s", utils.RandStringRunes(8))).
+		SetDescription("Second test prompt").
+		SetCreatorID(s.uid).
+		SetProjectID(project2.ID).
+		SaveX(context.Background())
+
+	// Create calls for different projects and prompts
+	call1 := s.createTestPromptCallWithProject(100.0, 1000, 800, now.AddDate(0, 0, -5), 0, false, s.projectID, s.promptID)
+	call2 := s.createTestPromptCallWithProject(200.0, 1500, 1200, now.AddDate(0, 0, -3), 0, false, project2.ID, prompt2.ID)
+
+	// Query cost reports
+	result, err := s.q.Reports(s.ctx, reportsArgs{
+		Filters: costReportFilters{
+			From: currentMonth,
+			To:   currentMonth,
+		},
+	})
+
+	assert.Nil(s.T(), err)
+
+	reports := result.Reports()
+	assert.Len(s.T(), reports, 1)
+
+	report := reports[0]
+
+	// Check provider breakdown
+	providerBreakdown := report.CostsByProvider()
+	assert.Len(s.T(), providerBreakdown, 1) // All calls use same provider
+	assert.Equal(s.T(), fmt.Sprintf("%d", s.provider.ID), providerBreakdown[0].ID())
+	assert.Equal(s.T(), 300.0, providerBreakdown[0].CostCents())
+	assert.Equal(s.T(), int32(2), providerBreakdown[0].Count())
+
+	// Check project breakdown
+	projectBreakdown := report.CostsByProject()
+	assert.Len(s.T(), projectBreakdown, 2) // Two different projects
+
+	// Check prompt breakdown
+	promptBreakdown := report.CostsByPrompt()
+	assert.Len(s.T(), promptBreakdown, 2) // Two different prompts
+
+	// Check daily breakdown
+	dailyBreakdown := report.CostsByDay()
+	assert.Len(s.T(), dailyBreakdown, 2) // Two different days
+
+	// Clean up
+	service.EntClient.PromptCall.DeleteOneID(call1.ID).ExecX(context.Background())
+	service.EntClient.PromptCall.DeleteOneID(call2.ID).ExecX(context.Background())
+	service.EntClient.Prompt.DeleteOneID(prompt2.ID).ExecX(context.Background())
+	service.EntClient.Project.DeleteOneID(project2.ID).ExecX(context.Background())
+}
+
+func (s *costReportTestSuite) TestCostBreakdownItemResponse_AllFields() {
+	item := service.CostBreakdownItem{
+		ID:        "123",
+		Name:      "Test Item",
+		CostCents: 456.78,
+		Count:     10,
+	}
+
+	response := costBreakdownItemResponse{item: item}
+
+	assert.Equal(s.T(), "123", response.ID())
+	assert.Equal(s.T(), "Test Item", response.Name())
+	assert.Equal(s.T(), 456.78, response.CostCents())
+	assert.Equal(s.T(), int32(10), response.Count())
+}
+
+func (s *costReportTestSuite) TestDailyCostResponse_AllFields() {
+	cost := service.DailyCost{
+		Date:      "2024-01-15",
+		CostCents: 123.45,
+		Count:     5,
+	}
+
+	response := dailyCostResponse{cost: cost}
+
+	assert.Equal(s.T(), "2024-01-15", response.Date())
+	assert.Equal(s.T(), 123.45, response.CostCents())
+	assert.Equal(s.T(), int32(5), response.Count())
+}
+
+func (s *costReportTestSuite) TestMonthlyCostReportResponse_AllFields() {
+	now := time.Now()
+	report := service.MonthlyCostReport{
+		Month:           "2024-01",
+		UserID:          "test-user",
+		TotalCostCents:  1234.56,
+		TotalCalls:      100,
+		TotalTokens:     50000,
+		SuccessfulCalls: 95,
+		CachedCalls:     10,
+		CostsByProvider: []service.CostBreakdownItem{
+			{ID: "1", Name: "Provider 1", CostCents: 600.0, Count: 60},
+			{ID: "2", Name: "Provider 2", CostCents: 634.56, Count: 40},
+		},
+		CostsByProject: []service.CostBreakdownItem{
+			{ID: "1", Name: "Project 1", CostCents: 1234.56, Count: 100},
+		},
+		CostsByPrompt: []service.CostBreakdownItem{
+			{ID: "1", Name: "Prompt 1", CostCents: 800.0, Count: 70},
+			{ID: "2", Name: "Prompt 2", CostCents: 434.56, Count: 30},
+		},
+		CostsByDay: []service.DailyCost{
+			{Date: "2024-01-01", CostCents: 100.0, Count: 10},
+			{Date: "2024-01-02", CostCents: 200.0, Count: 20},
+		},
+		CreatedAt: now,
+		UpdatedAt: now.Add(time.Hour),
+	}
+
+	response := monthlyCostReportResponse{report: report}
+
+	// Test basic fields
+	assert.Equal(s.T(), "2024-01", response.Month())
+	assert.Equal(s.T(), "test-user", response.UserId())
+	assert.Equal(s.T(), 1234.56, response.TotalCostCents())
+	assert.Equal(s.T(), int32(100), response.TotalCalls())
+	assert.Equal(s.T(), int32(50000), response.TotalTokens())
+	assert.Equal(s.T(), int32(95), response.SuccessfulCalls())
+	assert.Equal(s.T(), int32(10), response.CachedCalls())
+
+	// Test timestamps
+	assert.Equal(s.T(), now.Format(time.RFC3339), response.CreatedAt())
+	assert.Equal(s.T(), now.Add(time.Hour).Format(time.RFC3339), response.UpdatedAt())
+
+	// Test breakdown arrays
+	providers := response.CostsByProvider()
+	assert.Len(s.T(), providers, 2)
+	assert.Equal(s.T(), "Provider 1", providers[0].Name())
+
+	projects := response.CostsByProject()
+	assert.Len(s.T(), projects, 1)
+	assert.Equal(s.T(), "Project 1", projects[0].Name())
+
+	prompts := response.CostsByPrompt()
+	assert.Len(s.T(), prompts, 2)
+	assert.Equal(s.T(), "Prompt 1", prompts[0].Name())
+
+	days := response.CostsByDay()
+	assert.Len(s.T(), days, 2)
+	assert.Equal(s.T(), "2024-01-01", days[0].Date())
+}
+
+// Helper method to create test prompt calls
+func (s *costReportTestSuite) createTestPromptCall(costCents float64, totalTokens, responseTokens int, createdAt time.Time, result int, cached bool) *ent.PromptCall {
+	return s.createTestPromptCallWithProject(costCents, totalTokens, responseTokens, createdAt, result, cached, s.projectID, s.promptID)
+}
+
+// Helper method to create test prompt calls with specific project and prompt
+func (s *costReportTestSuite) createTestPromptCallWithProject(costCents float64, totalTokens, responseTokens int, createdAt time.Time, result int, cached bool, projectID, promptID int) *ent.PromptCall {
+	call := service.EntClient.PromptCall.Create().
+		SetPromptId(promptID).
+		SetUserId(s.uid).
+		SetResponseToken(responseTokens).
+		SetTotalToken(totalTokens).
+		SetDuration(1000).
+		SetResult(result).
+		SetCached(cached).
+		SetCostCents(costCents).
+		SetUa("PromptPal-Test/1.0").
+		SetIP("127.0.0.1").
+		SetProviderId(s.provider.ID).
+		SetCreateTime(createdAt).
+		SetUpdateTime(createdAt)
+
+	// Set project relation
+	created := call.SaveX(context.Background())
+
+	// Add project relationship
+	service.EntClient.Project.UpdateOneID(projectID).
+		AddCalls(created).
+		ExecX(context.Background())
+
+	return created
+}
+
+func (s *costReportTestSuite) TearDownSuite() {
+	// Clean up test data
+	service.EntClient.Provider.DeleteOneID(s.provider.ID).ExecX(context.Background())
+	service.EntClient.Prompt.DeleteOneID(s.promptID).ExecX(context.Background())
+	service.EntClient.Project.DeleteOneID(s.projectID).ExecX(context.Background())
+	service.EntClient.User.DeleteOneID(s.uid).ExecX(context.Background())
+
+	service.Close()
+}
+
+func TestCostReportTestSuite(t *testing.T) {
+	suite.Run(t, new(costReportTestSuite))
+}

--- a/schema/schema.gql
+++ b/schema/schema.gql
@@ -8,6 +8,7 @@
 #import * from './types/provider.gql'
 #import * from './types/webhook.gql'
 #import * from './types/webhook_call.gql'
+#import * from './types/cost_report.gql'
 
 schema {
   query: Query
@@ -31,6 +32,9 @@ type Query {
   # Webhook queries
   webhook(id: Int!): Webhook!
   webhooks(projectId: Int!, pagination: PaginationInput!): WebhookList!
+
+  # Cost report queries
+  reports(filters: CostReportFilters!): CostReportList!
 }
 
 type Mutation {

--- a/schema/types/cost_report.gql
+++ b/schema/types/cost_report.gql
@@ -1,0 +1,51 @@
+# Cost report types for aggregated cost data
+
+# Individual cost breakdown item
+type CostBreakdownItem {
+  id: String!
+  name: String!
+  costCents: Float!
+  count: Int!
+}
+
+# Daily cost data point
+type DailyCost {
+  date: String!  # YYYY-MM-DD format
+  costCents: Float!
+  count: Int!
+}
+
+# Monthly cost report with all aggregations
+type MonthlyCostReport {
+  month: String!  # YYYY-MM format
+  userId: String!
+  
+  # Total costs and counts
+  totalCostCents: Float!
+  totalCalls: Int!
+  totalTokens: Int!
+  successfulCalls: Int!
+  cachedCalls: Int!
+  
+  # Cost breakdowns by different dimensions
+  costsByProvider: [CostBreakdownItem!]!
+  costsByProject: [CostBreakdownItem!]!
+  costsByPrompt: [CostBreakdownItem!]!
+  costsByDay: [DailyCost!]!
+  
+  # Metadata
+  createdAt: String!
+  updatedAt: String!
+}
+
+# List of monthly cost reports
+type CostReportList {
+  reports: [MonthlyCostReport!]!
+  count: Int!
+}
+
+# Input for querying cost reports
+input CostReportFilters {
+  from: String!  # YYYY-MM format
+  to: String!    # YYYY-MM format
+}

--- a/service/cost_report.go
+++ b/service/cost_report.go
@@ -1,0 +1,589 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"github.com/PromptPal/PromptPal/ent"
+	"github.com/PromptPal/PromptPal/ent/costreport"
+	"github.com/PromptPal/PromptPal/ent/project"
+	"github.com/PromptPal/PromptPal/ent/prompt"
+	"github.com/PromptPal/PromptPal/ent/promptcall"
+	"github.com/PromptPal/PromptPal/ent/provider"
+	"github.com/go-redis/cache/v9"
+	"github.com/sirupsen/logrus"
+)
+
+// CostReportService handles cost report generation and caching
+type CostReportService struct{}
+
+// CostBreakdownItem represents a single item in cost breakdown
+type CostBreakdownItem struct {
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	CostCents float64 `json:"costCents"`
+	Count     int     `json:"count"`
+}
+
+// DailyCost represents cost data for a specific day
+type DailyCost struct {
+	Date      string  `json:"date"`
+	CostCents float64 `json:"costCents"`
+	Count     int     `json:"count"`
+}
+
+// MonthlyCostReport represents aggregated cost data for a month
+type MonthlyCostReport struct {
+	Month   string `json:"month"`   // YYYY-MM format
+	UserID  string `json:"userId"`
+
+	// Total costs and counts
+	TotalCostCents  float64 `json:"totalCostCents"`
+	TotalCalls      int     `json:"totalCalls"`
+	TotalTokens     int     `json:"totalTokens"`
+	SuccessfulCalls int     `json:"successfulCalls"`
+	CachedCalls     int     `json:"cachedCalls"`
+
+	// Cost breakdowns by different dimensions
+	CostsByProvider []CostBreakdownItem `json:"costsByProvider"`
+	CostsByProject  []CostBreakdownItem `json:"costsByProject"`
+	CostsByPrompt   []CostBreakdownItem `json:"costsByPrompt"`
+	CostsByDay      []DailyCost         `json:"costsByDay"`
+
+	// Metadata
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// GetCostReports retrieves cost reports for a user within a date range
+func (s *CostReportService) GetCostReports(ctx context.Context, userID, fromMonth, toMonth string) ([]MonthlyCostReport, error) {
+	fromTime, err := time.Parse("2006-01", fromMonth)
+	if err != nil {
+		return nil, fmt.Errorf("invalid from month format: %w", err)
+	}
+
+	toTime, err := time.Parse("2006-01", toMonth)
+	if err != nil {
+		return nil, fmt.Errorf("invalid to month format: %w", err)
+	}
+
+	var reports []MonthlyCostReport
+	currentMonth := fromTime
+
+	for currentMonth.Before(toTime.AddDate(0, 1, 0)) {
+		monthStr := currentMonth.Format("2006-01")
+		
+		// Check if this is the current month (use real-time data)
+		now := time.Now()
+		isCurrentMonth := monthStr == now.Format("2006-01")
+
+		var report *MonthlyCostReport
+		
+		if isCurrentMonth {
+			// Generate real-time report for current month
+			report, err = s.generateRealtimeReport(ctx, userID, monthStr)
+		} else {
+			// Try to get cached report first
+			report, err = s.getCachedReport(ctx, userID, monthStr)
+			if err != nil || report == nil {
+				// Generate and cache the report
+				report, err = s.generateAndCacheReport(ctx, userID, monthStr)
+			}
+		}
+
+		if err != nil {
+			logrus.WithError(err).Errorf("Failed to get cost report for %s/%s", userID, monthStr)
+			continue
+		}
+
+		if report != nil {
+			reports = append(reports, *report)
+		}
+
+		currentMonth = currentMonth.AddDate(0, 1, 0)
+	}
+
+	return reports, nil
+}
+
+// generateRealtimeReport generates a cost report in real-time for the current month
+func (s *CostReportService) generateRealtimeReport(ctx context.Context, userID, month string) (*MonthlyCostReport, error) {
+	monthTime, _ := time.Parse("2006-01", month)
+	startOfMonth := monthTime
+	endOfMonth := monthTime.AddDate(0, 1, 0)
+
+	return s.aggregatePromptCallsForMonth(ctx, userID, month, startOfMonth, endOfMonth)
+}
+
+// generateAndCacheReport generates a cost report and caches it for historical data
+func (s *CostReportService) generateAndCacheReport(ctx context.Context, userID, month string) (*MonthlyCostReport, error) {
+	monthTime, _ := time.Parse("2006-01", month)
+	startOfMonth := monthTime
+	endOfMonth := monthTime.AddDate(0, 1, 0)
+
+	report, err := s.aggregatePromptCallsForMonth(ctx, userID, month, startOfMonth, endOfMonth)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the report for 24 hours
+	cacheKey := fmt.Sprintf("cost-report:%s:%s", userID, month)
+	Cache.Set(&cache.Item{
+		Ctx:   ctx,
+		Key:   cacheKey,
+		Value: report,
+		TTL:   time.Hour * 24,
+	})
+
+	// Also save to database for persistence
+	err = s.saveToDB(ctx, report)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to save cost report to database")
+	}
+
+	return report, nil
+}
+
+// getCachedReport retrieves a cached cost report
+func (s *CostReportService) getCachedReport(ctx context.Context, userID, month string) (*MonthlyCostReport, error) {
+	// Try Redis cache first
+	cacheKey := fmt.Sprintf("cost-report:%s:%s", userID, month)
+	var report MonthlyCostReport
+	err := Cache.Get(ctx, cacheKey, &report)
+	if err == nil {
+		return &report, nil
+	}
+
+	// Try database if cache miss
+	dbReport, err := EntClient.CostReport.Query().
+		Where(costreport.UserId(userID)).
+		Where(costreport.Month(month)).
+		First(ctx)
+	
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, nil // Not found, will generate new report
+		}
+		return nil, err
+	}
+
+	// Convert database report to service report
+	return s.convertDBToServiceReport(dbReport), nil
+}
+
+// aggregatePromptCallsForMonth performs the actual aggregation of PromptCall data
+func (s *CostReportService) aggregatePromptCallsForMonth(ctx context.Context, userID, month string, startTime, endTime time.Time) (*MonthlyCostReport, error) {
+	report := &MonthlyCostReport{
+		Month:     month,
+		UserID:    userID,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	// Get total statistics
+	err := s.aggregateTotalStats(ctx, userID, startTime, endTime, report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate total stats: %w", err)
+	}
+
+	// Get costs by provider
+	err = s.aggregateCostsByProvider(ctx, userID, startTime, endTime, report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate costs by provider: %w", err)
+	}
+
+	// Get costs by project
+	err = s.aggregateCostsByProject(ctx, userID, startTime, endTime, report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate costs by project: %w", err)
+	}
+
+	// Get costs by prompt
+	err = s.aggregateCostsByPrompt(ctx, userID, startTime, endTime, report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate costs by prompt: %w", err)
+	}
+
+	// Get costs by day
+	err = s.aggregateCostsByDay(ctx, userID, startTime, endTime, report)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate costs by day: %w", err)
+	}
+
+	return report, nil
+}
+
+// aggregateTotalStats aggregates total statistics for the month
+func (s *CostReportService) aggregateTotalStats(ctx context.Context, userID string, startTime, endTime time.Time, report *MonthlyCostReport) error {
+	baseQuery := EntClient.PromptCall.Query().
+		Where(promptcall.UserId(userID)).
+		Where(promptcall.CreateTimeGTE(startTime)).
+		Where(promptcall.CreateTimeLT(endTime))
+
+	// Get total count
+	totalCalls, err := baseQuery.Clone().Count(ctx)
+	if err != nil {
+		return err
+	}
+	report.TotalCalls = totalCalls
+
+	// Get successful calls count
+	successfulCalls, err := baseQuery.Clone().
+		Where(promptcall.Result(0)).
+		Count(ctx)
+	if err != nil {
+		return err
+	}
+	report.SuccessfulCalls = successfulCalls
+
+	// Get cached calls count
+	cachedCalls, err := baseQuery.Clone().
+		Where(promptcall.Cached(true)).
+		Count(ctx)
+	if err != nil {
+		return err
+	}
+	report.CachedCalls = cachedCalls
+
+	// Get aggregated cost and tokens using custom SQL
+	var result []struct {
+		TotalCost   float64 `json:"total_cost"`
+		TotalTokens int     `json:"total_tokens"`
+	}
+
+	err = baseQuery.Clone().
+		Aggregate(func(s *sql.Selector) string {
+			return sql.As("COALESCE(SUM(cost_cents), 0)", "total_cost")
+		}, func(s *sql.Selector) string {
+			return sql.As("COALESCE(SUM(total_token), 0)", "total_tokens")
+		}).
+		Scan(ctx, &result)
+
+	if err != nil {
+		return err
+	}
+
+	if len(result) > 0 {
+		report.TotalCostCents = result[0].TotalCost
+		report.TotalTokens = result[0].TotalTokens
+	}
+
+	return nil
+}
+
+// aggregateCostsByProvider aggregates costs grouped by provider
+func (s *CostReportService) aggregateCostsByProvider(ctx context.Context, userID string, startTime, endTime time.Time, report *MonthlyCostReport) error {
+	var result []struct {
+		ProviderID int     `json:"provider_id"`
+		TotalCost  float64 `json:"total_cost"`
+		Count      int     `json:"count"`
+	}
+
+	err := EntClient.PromptCall.Query().
+		Where(promptcall.UserId(userID)).
+		Where(promptcall.CreateTimeGTE(startTime)).
+		Where(promptcall.CreateTimeLT(endTime)).
+		Where(promptcall.ProviderIdNotNil()).
+		GroupBy(promptcall.FieldProviderId).
+		Aggregate(func(s *sql.Selector) string {
+			return sql.As("COALESCE(SUM(cost_cents), 0)", "total_cost")
+		}, func(s *sql.Selector) string {
+			return sql.As("COUNT(*)", "count") 
+		}).
+		Scan(ctx, &result)
+
+	if err != nil {
+		return err
+	}
+
+	// Get provider names
+	providerIDs := make([]int, len(result))
+	for i, r := range result {
+		providerIDs[i] = r.ProviderID
+	}
+
+	providers, err := EntClient.Provider.Query().
+		Where(provider.IDIn(providerIDs...)).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+
+	providerMap := make(map[int]string)
+	for _, p := range providers {
+		providerMap[p.ID] = p.Name
+	}
+
+	for _, r := range result {
+		name := providerMap[r.ProviderID]
+		if name == "" {
+			name = fmt.Sprintf("Provider %d", r.ProviderID)
+		}
+
+		report.CostsByProvider = append(report.CostsByProvider, CostBreakdownItem{
+			ID:        fmt.Sprintf("%d", r.ProviderID),
+			Name:      name,
+			CostCents: r.TotalCost,
+			Count:     r.Count,
+		})
+	}
+
+	return nil
+}
+
+// aggregateCostsByProject aggregates costs grouped by project
+func (s *CostReportService) aggregateCostsByProject(ctx context.Context, userID string, startTime, endTime time.Time, report *MonthlyCostReport) error {
+	var result []struct {
+		ProjectID int     `json:"project_id"`
+		TotalCost float64 `json:"total_cost"`
+		Count     int     `json:"count"`
+	}
+
+	err := EntClient.PromptCall.Query().
+		Where(promptcall.UserId(userID)).
+		Where(promptcall.CreateTimeGTE(startTime)).
+		Where(promptcall.CreateTimeLT(endTime)).
+		GroupBy("project_calls").
+		Aggregate(func(s *sql.Selector) string {
+			return sql.As("COALESCE(SUM(cost_cents), 0)", "total_cost")
+		}, func(s *sql.Selector) string {
+			return sql.As("COUNT(*)", "count") 
+		}).
+		Scan(ctx, &result)
+
+	if err != nil {
+		return err
+	}
+
+	// Get project names
+	projectIDs := make([]int, len(result))
+	for i, r := range result {
+		projectIDs[i] = r.ProjectID
+	}
+
+	projects, err := EntClient.Project.Query().
+		Where(project.IDIn(projectIDs...)).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+
+	projectMap := make(map[int]string)
+	for _, p := range projects {
+		projectMap[p.ID] = p.Name
+	}
+
+	for _, r := range result {
+		name := projectMap[r.ProjectID]
+		if name == "" {
+			name = fmt.Sprintf("Project %d", r.ProjectID)
+		}
+
+		report.CostsByProject = append(report.CostsByProject, CostBreakdownItem{
+			ID:        fmt.Sprintf("%d", r.ProjectID),
+			Name:      name,
+			CostCents: r.TotalCost,
+			Count:     r.Count,
+		})
+	}
+
+	return nil
+}
+
+// aggregateCostsByPrompt aggregates costs grouped by prompt
+func (s *CostReportService) aggregateCostsByPrompt(ctx context.Context, userID string, startTime, endTime time.Time, report *MonthlyCostReport) error {
+	var result []struct {
+		PromptID  int     `json:"prompt_id"`
+		TotalCost float64 `json:"total_cost"`
+		Count     int     `json:"count"`
+	}
+
+	err := EntClient.PromptCall.Query().
+		Where(promptcall.UserId(userID)).
+		Where(promptcall.CreateTimeGTE(startTime)).
+		Where(promptcall.CreateTimeLT(endTime)).
+		GroupBy(promptcall.FieldPromptId).
+		Aggregate(func(s *sql.Selector) string {
+			return sql.As("COALESCE(SUM(cost_cents), 0)", "total_cost")
+		}, func(s *sql.Selector) string {
+			return sql.As("COUNT(*)", "count") 
+		}).
+		Scan(ctx, &result)
+
+	if err != nil {
+		return err
+	}
+
+	// Get prompt titles
+	promptIDs := make([]int, len(result))
+	for i, r := range result {
+		promptIDs[i] = r.PromptID
+	}
+
+	prompts, err := EntClient.Prompt.Query().
+		Where(prompt.IDIn(promptIDs...)).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+
+	promptMap := make(map[int]string)
+	for _, p := range prompts {
+		promptMap[p.ID] = p.Name
+	}
+
+	for _, r := range result {
+		name := promptMap[r.PromptID]
+		if name == "" {
+			name = fmt.Sprintf("Prompt %d", r.PromptID)
+		}
+
+		report.CostsByPrompt = append(report.CostsByPrompt, CostBreakdownItem{
+			ID:        fmt.Sprintf("%d", r.PromptID),
+			Name:      name,
+			CostCents: r.TotalCost,
+			Count:     r.Count,
+		})
+	}
+
+	return nil
+}
+
+// aggregateCostsByDay aggregates costs grouped by day
+func (s *CostReportService) aggregateCostsByDay(ctx context.Context, userID string, startTime, endTime time.Time, report *MonthlyCostReport) error {
+	var result []struct {
+		Date      string  `json:"date"`
+		TotalCost float64 `json:"total_cost"`
+		Count     int     `json:"count"`
+	}
+
+	err := EntClient.PromptCall.Query().
+		Where(promptcall.UserId(userID)).
+		Where(promptcall.CreateTimeGTE(startTime)).
+		Where(promptcall.CreateTimeLT(endTime)).
+		Aggregate(
+			func(s *sql.Selector) string {
+				return sql.As("DATE(create_time)", "date")
+			},
+			func(s *sql.Selector) string {
+				return sql.As("COALESCE(SUM(cost_cents), 0)", "total_cost")
+			},
+			func(s *sql.Selector) string {
+				return sql.As("COUNT(*)", "count")
+			},
+		).
+		Modify(func(s *sql.Selector) {
+			s.GroupBy("date")
+			s.OrderBy(sql.Asc("date"))
+		}).
+		Scan(ctx, &result)
+
+	if err != nil {
+		return err
+	}
+
+	for _, r := range result {
+		report.CostsByDay = append(report.CostsByDay, DailyCost{
+			Date:      r.Date,
+			CostCents: r.TotalCost,
+			Count:     r.Count,
+		})
+	}
+
+	return nil
+}
+
+// saveToDB saves the cost report to the database
+func (s *CostReportService) saveToDB(ctx context.Context, report *MonthlyCostReport) error {
+	// Convert cost breakdowns to map[string]float64 for JSON storage
+	costsByProvider := convertToStringFloatMap(report.CostsByProvider)
+	costsByProject := convertToStringFloatMap(report.CostsByProject)
+	costsByPrompt := convertToStringFloatMap(report.CostsByPrompt)
+	costsByDay := convertDailyCostsToStringFloatMap(report.CostsByDay)
+
+	// Create or update the cost report
+	err := EntClient.CostReport.Create().
+		SetMonth(report.Month).
+		SetUserId(report.UserID).
+		SetTotalCostCents(report.TotalCostCents).
+		SetCostsByProvider(costsByProvider).
+		SetCostsByProject(costsByProject).
+		SetCostsByPrompt(costsByPrompt).
+		SetCostsByDay(costsByDay).
+		SetTotalCalls(report.TotalCalls).
+		SetTotalTokens(report.TotalTokens).
+		SetSuccessfulCalls(report.SuccessfulCalls).
+		SetCachedCalls(report.CachedCalls).
+		OnConflict().
+		UpdateNewValues().
+		Exec(ctx)
+
+	return err
+}
+
+// convertDBToServiceReport converts database entity to service model
+func (s *CostReportService) convertDBToServiceReport(dbReport *ent.CostReport) *MonthlyCostReport {
+	report := &MonthlyCostReport{
+		Month:           dbReport.Month,
+		UserID:          dbReport.UserId,
+		TotalCostCents:  dbReport.TotalCostCents,
+		TotalCalls:      dbReport.TotalCalls,
+		TotalTokens:     dbReport.TotalTokens,
+		SuccessfulCalls: dbReport.SuccessfulCalls,
+		CachedCalls:     dbReport.CachedCalls,
+		CreatedAt:       dbReport.CreateTime,
+		UpdatedAt:       dbReport.UpdateTime,
+	}
+
+	// Convert JSON fields back to structured data
+	report.CostsByProvider = convertStringFloatMapToBreakdown(dbReport.CostsByProvider)
+	report.CostsByProject = convertStringFloatMapToBreakdown(dbReport.CostsByProject)
+	report.CostsByPrompt = convertStringFloatMapToBreakdown(dbReport.CostsByPrompt)
+	report.CostsByDay = convertStringFloatMapToDailyCosts(dbReport.CostsByDay)
+
+	return report
+}
+
+// Helper functions for JSON conversion
+func convertToStringFloatMap(items []CostBreakdownItem) map[string]float64 {
+	result := make(map[string]float64)
+	for _, item := range items {
+		result[item.ID] = item.CostCents
+	}
+	return result
+}
+
+func convertDailyCostsToStringFloatMap(costs []DailyCost) map[string]float64 {
+	result := make(map[string]float64)
+	for _, cost := range costs {
+		result[cost.Date] = cost.CostCents
+	}
+	return result
+}
+
+func convertStringFloatMapToBreakdown(jsonData map[string]float64) []CostBreakdownItem {
+	var result []CostBreakdownItem
+	for id, cost := range jsonData {
+		result = append(result, CostBreakdownItem{
+			ID:        id,
+			Name:      id, // Will be resolved later with actual names
+			CostCents: cost,
+			Count:     0, // Not stored in DB, would need separate aggregation
+		})
+	}
+	return result
+}
+
+func convertStringFloatMapToDailyCosts(jsonData map[string]float64) []DailyCost {
+	var result []DailyCost
+	for date, cost := range jsonData {
+		result = append(result, DailyCost{
+			Date:      date,
+			CostCents: cost,
+			Count:     0, // Not stored in DB, would need separate aggregation
+		})
+	}
+	return result
+}


### PR DESCRIPTION
## Summary
- Add database schema for monthly cost reports with caching
- Create comprehensive GraphQL types for cost breakdowns
- Implement reports query with date range filtering
- Add service layer with Redis caching and real-time data
- Include costs grouped by provider, project, prompt, and day
- Add comprehensive test suite following existing patterns

## Test plan
- [ ] Run go generate to update entity code
- [ ] Test GraphQL query with sample data
- [ ] Verify Redis caching works for historical data
- [ ] Test real-time data for current month
- [ ] Validate all cost breakdowns return correct data

🤖 Generated with [Claude Code](https://claude.ai/code)