### PR TITLE
feat(auth): change temporaryTokenValidationResponse.UserId from int to string

### DIFF
--- a/routes/prompt.api.go
+++ b/routes/prompt.api.go
@@ -214,7 +214,7 @@ func apiRunPrompt(c *gin.Context) {
 	pjData, _ := c.Get("pj")
 	payloadData, _ := c.Get("payload")
 
-	serverUid := c.GetInt("server_uid")
+	serverUid := c.GetString("server_uid")
 
 	prompt := promptData.(ent.Prompt)
 	pj := pjData.(ent.Project)
@@ -233,8 +233,8 @@ func apiRunPrompt(c *gin.Context) {
 	}
 
 	requestUid := payload.UserId
-	if payload.UserId == "" && serverUid > 0 {
-		requestUid = fmt.Sprintf("%d", serverUid)
+	if payload.UserId == "" && serverUid != "" {
+		requestUid = serverUid
 	}
 
 	res, err := isomorphicAIService.Chat(c, provider, prompt, payload.Variables, requestUid)

--- a/routes/security.middleware.go
+++ b/routes/security.middleware.go
@@ -11,9 +11,9 @@ import (
 )
 
 type temporaryTokenValidationResponse struct {
-	Limit     int `json:"limit"`
-	Remaining int `json:"remaining"`
-	UserId    int `json:"userId"`
+	Limit     int    `json:"limit"`
+	Remaining int    `json:"remaining"`
+	UserId    string `json:"userId"`
 }
 
 func temporaryTokenValidationMiddleware(c *gin.Context) {
@@ -92,7 +92,7 @@ func temporaryTokenValidationMiddleware(c *gin.Context) {
 		})
 		return
 	}
-	if resp.UserId > 0 {
+	if resp.UserId != "" {
 		c.Set("server_uid", resp.UserId)
 	}
 	c.Next()


### PR DESCRIPTION
This change allows supporting external services that may use string-based user IDs instead of integers, providing more flexibility for API validation.

Changes:
- Updated temporaryTokenValidationResponse struct field from int to string
- Modified condition check from resp.UserId > 0 to resp.UserId != ""
- Changed c.GetInt("server_uid") to c.GetString("server_uid") in prompt API
- Updated serverUid usage logic to work with string values

Fixes #125

Generated with [Claude Code](https://claude.ai/code)