### PR TITLE
feat: standardize User-Agent header format for webhooks

### DIFF
--- a/docs/webhook-integration.md
+++ b/docs/webhook-integration.md
@@ -25,7 +25,7 @@ PromptPal sends the following headers with each webhook request:
 
 ```http
 Content-Type: application/json
-User-Agent: PromptPal-Webhook@{version}
+User-Agent: PromptPal@{version}
 ```
 
 ### Timeout

--- a/routes/webhook.service.go
+++ b/routes/webhook.service.go
@@ -149,7 +149,7 @@ func sendWebhookRequest(ctx context.Context, webhook *ent.Webhook, payloadBytes 
 	// Prepare request headers
 	requestHeaders := map[string]string{
 		"Content-Type": "application/json",
-		"User-Agent":   fmt.Sprintf("PromptPal-Webhook@%s", versionCommit),
+		"User-Agent":   fmt.Sprintf("PromptPal@%s", versionCommit),
 	}
 
 	// Create HTTP request


### PR DESCRIPTION
Update webhook User-Agent from "PromptPal-Webhook@{version}" to "PromptPal@{version}" to match the consistent format used in other HTTP requests throughout the codebase.

Also updated webhook integration documentation to reflect the new format.

Fixes #128

Generated with [Claude Code](https://claude.ai/code)